### PR TITLE
refactor: Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

### DIFF
--- a/src/main/java/ch/heigvd/pdl/refactoring/OrdersWriter.java
+++ b/src/main/java/ch/heigvd/pdl/refactoring/OrdersWriter.java
@@ -9,7 +9,7 @@ public class OrdersWriter {
     }
 
     public String getContents() {
-        StringBuffer sb = new StringBuffer("{\"orders\": [");
+        StringBuilder sb = new StringBuilder("{\"orders\": [");
 
         for (int i = 0; i < orders.getOrdersCount(); i++) {
             Order order = orders.getOrder(i);


### PR DESCRIPTION
Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

Replace a synchronized class "StringBuffer" by an unsynchronized one such as "StringBuilder".