### PR TITLE
refactor: A field should not duplicate the name of its containing class

### DIFF
--- a/src/main/java/ch/heigvd/pdl/refactoring/Orders.java
+++ b/src/main/java/ch/heigvd/pdl/refactoring/Orders.java
@@ -5,18 +5,18 @@ import java.util.List;
 
 public class Orders {
 
-    private List<Order> orders = new ArrayList<Order>();
+    private List<Order> ordersList = new ArrayList<Order>();
 
     public void AddOrder(Order order) {
-        orders.add(order);
+        ordersList.add(order);
     }
 
     public int getOrdersCount() {
-        return orders.size();
+        return ordersList.size();
     }
 
     public Order getOrder(int i) {
-        return orders.get(i);
+        return ordersList.get(i);
     }
 
 }


### PR DESCRIPTION
Renamed the list of objects with a better name