### PR TITLE
refactor: add size and color enums for products instead of switch sta…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,12 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <sonar.organization>pdl-classroom</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
+        <jacoco.version>0.8.8</jacoco.version>
+        <sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
+        <sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
+        <sonar.coverage.jacoco.xmlReportPaths>${basedir}/target/jacoco_report/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+        <jacoco.path>${basedir}/target/jacoco_report</jacoco.path>
+        <sonar.language>java</sonar.language>
     </properties>
 
     <build>
@@ -22,6 +28,26 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.1.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <executions>
+                    <execution>
+                        <id>jacoco-initialize</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>jacoco-site</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
@@ -34,6 +60,11 @@
             <artifactId>junit-jupiter</artifactId>
             <version>5.8.1</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <version>0.8.8</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/ch/heigvd/pdl/refactoring/OrdersWriter.java
+++ b/src/main/java/ch/heigvd/pdl/refactoring/OrdersWriter.java
@@ -26,12 +26,12 @@ public class OrdersWriter {
                 sb.append(product.getCode());
                 sb.append("\", ");
                 sb.append("\"color\": \"");
-                sb.append(getColorFor(product));
+                sb.append(product.getColor());
                 sb.append("\", ");
 
-                if (product.getSize() != Product.SIZE_NOT_APPLICABLE) {
+                if (product.getSize() != ProductSize.INVALID_SIZE) {
                     sb.append("\"size\": \"");
-                    sb.append(getSizeFor(product));
+                    sb.append(product.getSize());
                     sb.append("\", ");
                 }
 
@@ -56,37 +56,5 @@ public class OrdersWriter {
         }
 
         return sb.append("]}").toString();
-    }
-
-    private String getSizeFor(Product product) {
-        switch (product.getSize()) {
-            case 1:
-                return "XS";
-            case 2:
-                return "S";
-            case 3:
-                return "M";
-            case 4:
-                return "L";
-            case 5:
-                return "XL";
-            case 6:
-                return "XXL";
-            default:
-                return "Invalid Size";
-        }
-    }
-
-    private String getColorFor(Product product) {
-        switch (product.getColor()) {
-            case 1:
-                return "blue";
-            case 2:
-                return "red";
-            case 3:
-                return "yellow";
-            default:
-                return "no color";
-        }
     }
 }

--- a/src/main/java/ch/heigvd/pdl/refactoring/Product.java
+++ b/src/main/java/ch/heigvd/pdl/refactoring/Product.java
@@ -2,15 +2,13 @@ package ch.heigvd.pdl.refactoring;
 
 public class Product {
 
-    public static final int SIZE_NOT_APPLICABLE = -1;
-
     private String code;
-    private int color;
-    private int size;
+    private ProductColor color;
+    private ProductSize size;
     private double price;
     private String currency;
 
-    public Product(String code, int color, int size, double price, String currency) {
+    public Product(String code, ProductColor color, ProductSize size, double price, String currency) {
         this.code = code;
         this.color = color;
         this.size = size;
@@ -22,11 +20,11 @@ public class Product {
         return code;
     }
 
-    public int getColor() {
+    public ProductColor getColor() {
         return color;
     }
 
-    public int getSize() {
+    public ProductSize getSize() {
         return size;
     }
 

--- a/src/main/java/ch/heigvd/pdl/refactoring/ProductColor.java
+++ b/src/main/java/ch/heigvd/pdl/refactoring/ProductColor.java
@@ -1,0 +1,17 @@
+package ch.heigvd.pdl.refactoring;
+
+public enum ProductColor {
+    BLUE("blue"),
+    RED("red"),
+    YELLOW("yellow"),
+    NO_COLOR("no color");
+    public final String label;
+
+    ProductColor(String label) {
+        this.label = label;
+    }
+    @Override
+    public String toString() {
+        return this.label;
+    }
+}

--- a/src/main/java/ch/heigvd/pdl/refactoring/ProductSize.java
+++ b/src/main/java/ch/heigvd/pdl/refactoring/ProductSize.java
@@ -1,0 +1,22 @@
+package ch.heigvd.pdl.refactoring;
+
+public enum ProductSize {
+    XS("XS"),
+    S("S"),
+    M("M"),
+    L("L"),
+    XL("XL"),
+    XXL("XXL"),
+    INVALID_SIZE("Invalid Size");
+
+    public final String label;
+
+    ProductSize(String label) {
+        this.label = label;
+    }
+
+    @Override
+    public String toString() {
+        return this.label;
+    }
+}

--- a/src/test/java/ch/heigvd/pdl/refactoring/OrdersWriterTest.java
+++ b/src/test/java/ch/heigvd/pdl/refactoring/OrdersWriterTest.java
@@ -34,14 +34,14 @@ class OrdersWriterTest {
 
     @Test
     void OneOrderWithOneProduct() {
-        order111.addProduct(new Product("Shirt", 1, 3, 2.99, "TWD"));
+        order111.addProduct(new Product("Shirt", ProductColor.BLUE, ProductSize.M, 2.99, "TWD"));
         String order111Json = JsonOrder111WithProduct("{\"code\": \"Shirt\", \"color\": \"blue\", \"size\": \"M\", \"price\": 2.99, \"currency\": \"TWD\"}");
         assertEquals("{\"orders\": [" + order111Json + "]}", new OrdersWriter(orders).getContents());
     }
 
     @Test
     void OneOrderWithOneProductNoSize() {
-        order111.addProduct(new Product("Pot", 2, -1, 16.50, "SGD"));
+        order111.addProduct(new Product("Pot", ProductColor.RED, ProductSize.INVALID_SIZE, 16.50, "SGD"));
         String order111Json = JsonOrder111WithProduct("{\"code\": \"Pot\", \"color\": \"red\", \"price\": 16.5, \"currency\": \"SGD\"}");
         assertEquals("{\"orders\": [" + order111Json + "]}", new OrdersWriter(orders).getContents());
     }

--- a/src/test/java/ch/heigvd/pdl/refactoring/OrdersWriterTest.java
+++ b/src/test/java/ch/heigvd/pdl/refactoring/OrdersWriterTest.java
@@ -50,4 +50,27 @@ class OrdersWriterTest {
         return "{\"id\": 111, \"products\": [" + productJson + "]}";
     }
 
+    @Test
+    void ProductColor() {
+        Product p = new Product("Plane", ProductColor.RED, ProductSize.INVALID_SIZE, 99.00, "TRY");
+        assertEquals(ProductColor.RED, p.getColor());
+    }
+
+    @Test
+    void ProductColorValue() {
+        Product p = new Product("Plane", ProductColor.RED, ProductSize.INVALID_SIZE, 99.00, "TRY");
+        assertEquals("red", p.getColor().toString());
+    }
+
+    @Test
+    void ProductSize() {
+        Product p = new Product("Carpet", ProductColor.BLUE, ProductSize.XXL, 13.37, "TRY");
+        assertEquals(ProductSize.XXL, p.getSize());
+    }
+
+    @Test
+    void ProductSizeValue() {
+        Product p = new Product("Carpet", ProductColor.BLUE, ProductSize.XXL, 13.37, "TRY");
+        assertEquals("XXL", p.getSize().toString());
+    }
 }

--- a/src/test/java/ch/heigvd/pdl/refactoring/OrdersWriterTest.java
+++ b/src/test/java/ch/heigvd/pdl/refactoring/OrdersWriterTest.java
@@ -49,28 +49,4 @@ class OrdersWriterTest {
     private String JsonOrder111WithProduct(String productJson) {
         return "{\"id\": 111, \"products\": [" + productJson + "]}";
     }
-
-    @Test
-    void ProductColor() {
-        Product p = new Product("Plane", ProductColor.RED, ProductSize.INVALID_SIZE, 99.00, "TRY");
-        assertEquals(ProductColor.RED, p.getColor());
-    }
-
-    @Test
-    void ProductColorValue() {
-        Product p = new Product("Plane", ProductColor.RED, ProductSize.INVALID_SIZE, 99.00, "TRY");
-        assertEquals("red", p.getColor().toString());
-    }
-
-    @Test
-    void ProductSize() {
-        Product p = new Product("Carpet", ProductColor.BLUE, ProductSize.XXL, 13.37, "TRY");
-        assertEquals(ProductSize.XXL, p.getSize());
-    }
-
-    @Test
-    void ProductSizeValue() {
-        Product p = new Product("Carpet", ProductColor.BLUE, ProductSize.XXL, 13.37, "TRY");
-        assertEquals("XXL", p.getSize().toString());
-    }
 }

--- a/src/test/java/ch/heigvd/pdl/refactoring/ProductTest.java
+++ b/src/test/java/ch/heigvd/pdl/refactoring/ProductTest.java
@@ -1,0 +1,27 @@
+package ch.heigvd.pdl.refactoring;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ProductTest {
+    Product product = new Product("Carpet", ProductColor.BLUE, ProductSize.XXL, 13.37, "TRY");
+    @Test
+    void ProductColor() {
+        assertEquals(ProductColor.BLUE, product.getColor());
+    }
+
+    @Test
+    void ProductColorValue() {
+        assertEquals("blue", product.getColor().toString());
+    }
+
+    @Test
+    void ProductSize() {
+        assertEquals(ProductSize.XXL, product.getSize());
+    }
+
+    @Test
+    void ProductSizeValue() {
+        assertEquals("XXL", product.getSize().toString());
+    }
+}

--- a/src/test/java/ch/heigvd/pdl/refactoring/ProductTest.java
+++ b/src/test/java/ch/heigvd/pdl/refactoring/ProductTest.java
@@ -3,7 +3,7 @@ package ch.heigvd.pdl.refactoring;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class ProductTest {
+class ProductTest {
     Product product = new Product("Carpet", ProductColor.BLUE, ProductSize.XXL, 13.37, "TRY");
     @Test
     void ProductColor() {


### PR DESCRIPTION
…tements

Use enumerations with values instead of using switch statements for product sizes and product colors.

Product constructor was modified to accept ProductSize and ProductColor as parameters instead of integers. Removed the constant SIZE_NOT_APPLICABLE to use the enum instead. OrdersWriter was modified to use the enumeration.
Tests were modified accordingly.
A new test class has been added to cover the new enumerations as well.
